### PR TITLE
Set to Traefik's lowest priority

### DIFF
--- a/.ansible/templates/docker-compose.yaml.j2
+++ b/.ansible/templates/docker-compose.yaml.j2
@@ -19,6 +19,7 @@ services:
         - traefik.http.routers.coming-soon.tls.certresolver=step-ca
         - traefik.http.routers.coming-soon.tls.domains[0].main={{ proxy_domains[0] }}
         - traefik.http.routers.coming-soon.tls.domains[0].sans={{ proxy_domains[0] }}
+        - traefik.http.routers.coming-soon.priority=1
     networks:
       - {{ docker_network }}
 


### PR DESCRIPTION
priority 1 - to act as a true fallback page that's only displayed when something is down